### PR TITLE
Harden input handling to prevent SQL-like payloads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx

--- a/src/README.md
+++ b/src/README.md
@@ -48,3 +48,25 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Security Conventions
+
+- Do not add endpoints that accept raw SQL strings from users.
+- Validate user-supplied values before they reach persistence/query layers.
+- When database support is introduced, use parameterized queries or ORM-generated SQL only.
+
+Unsafe pattern (never allow):
+
+```python
+# Never execute user input as SQL
+cursor.execute(user_sql)
+```
+
+Safe pattern (parameterized):
+
+```python
+cursor.execute(
+   "SELECT * FROM activities WHERE name = ?",
+   (activity_name,),
+)
+```

--- a/src/app.py
+++ b/src/app.py
@@ -10,9 +10,16 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import re
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Reject obvious SQL payload patterns in user-supplied fields.
+SQL_PAYLOAD_PATTERN = re.compile(
+    r"(;|--|/\*|\*/|\b(select|insert|update|delete|drop|alter|create|union|exec|pragma|attach)\b)",
+    flags=re.IGNORECASE,
+)
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -88,9 +95,21 @@ def get_activities():
     return activities
 
 
+def reject_sql_like_input(field_name: str, value: str) -> None:
+    """Block payloads that look like SQL fragments to reduce injection risk."""
+    if SQL_PAYLOAD_PATTERN.search(value):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Potential SQL payload detected in '{field_name}'",
+        )
+
+
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
+    reject_sql_like_input("activity_name", activity_name)
+    reject_sql_like_input("email", email)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -113,6 +132,9 @@ def signup_for_activity(activity_name: str, email: str):
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
+    reject_sql_like_input("activity_name", activity_name)
+    reject_sql_like_input("email", email)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/tests/test_security_guards.py
+++ b/tests/test_security_guards.py
@@ -1,0 +1,53 @@
+import copy
+import unittest
+
+from fastapi.testclient import TestClient
+
+from src.app import app, activities
+
+
+class SecurityGuardsTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.original_activities = copy.deepcopy(activities)
+
+    def tearDown(self):
+        activities.clear()
+        activities.update(self.original_activities)
+
+    def test_signup_blocks_sql_like_email_payload(self):
+        response = self.client.post(
+            "/activities/Chess Club/signup",
+            params={"email": "student@example.com'; DROP TABLE users; --"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Potential SQL payload", response.json()["detail"])
+        self.assertNotIn(
+            "student@example.com'; DROP TABLE users; --",
+            activities["Chess Club"]["participants"],
+        )
+
+    def test_signup_blocks_sql_like_activity_name_payload(self):
+        response = self.client.post(
+            "/activities/Chess Club; SELECT * FROM users/signup",
+            params={"email": "student@example.com"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Potential SQL payload", response.json()["detail"])
+
+    def test_signup_still_allows_normal_input(self):
+        email = "new.student@mergington.edu"
+
+        response = self.client.post(
+            "/activities/Chess Club/signup",
+            params={"email": email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(email, activities["Chess Club"]["participants"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements security hardening for issue #16 by blocking SQL-like payloads in user inputs and adding regression tests.

## Changes
- Added a centralized SQL payload detector in `src/app.py`
- Enforced validation for `activity_name` and `email` in signup/unregister endpoints
- Added security regression tests in `tests/test_security_guards.py`
- Documented secure query conventions in `src/README.md`
- Added `httpx` to `requirements.txt` for test client support

## Validation
- Ran: `/workspaces/skills-integrate-mcp-with-copilot/.venv/bin/python -m unittest discover -s tests -v`
- Result: `3 tests, all passed`

Closes #16